### PR TITLE
Fix configs and linting errors

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+# editorconfig.org
+root = true
+
+[*]
+indent_size = 2
+indent_style = space
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "bootstrap": "^4.1.3",
+    "copy-webpack-plugin": "^4.6.0",
     "material-icons": "^0.2.3",
     "prerender-spa-plugin": "^3.4.0",
     "register-service-worker": "^1.0.0",
@@ -29,7 +30,6 @@
     "@vue/test-utils": "^1.0.0-beta.20",
     "babel-core": "7.0.0-bridge.0",
     "babel-jest": "^23.0.1",
-    "copy-webpack-plugin": "^4.6.0",
     "node-sass": "^4.9.0",
     "sass-loader": "^7.0.1",
     "vue-template-compiler": "^2.5.17"

--- a/public/admin/index.html
+++ b/public/admin/index.html
@@ -1,17 +1,17 @@
 <!doctype html>
 <html>
-    <head>
-        <meta charset="utf-8"/>
-        <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-        <title>Content Manager</title>
+  <head>
+    <meta charset="utf-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+    <title>Content Manager</title>
 
-        <!-- Include the styles for the Netlify CMS UI, after your own styles -->
-        <link rel="stylesheet" href="https://unpkg.com/netlify-cms@^1.0.0/dist/cms.css"/>
+    <!-- Include the styles for the Netlify CMS UI, after your own styles -->
+    <link rel="stylesheet" href="https://unpkg.com/netlify-cms@^1.0.0/dist/cms.css"/>
 
-    </head>
-    <body>
-        <!-- Include the script that builds the page and powers Netlify CMS -->
-        <script src="https://unpkg.com/netlify-cms@^2.0.0/dist/netlify-cms.js"></script>
-        <script src="https://identity.netlify.com/v1/netlify-identity-widget.js"></script>
-    </body>
+  </head>
+  <body>
+    <!-- Include the script that builds the page and powers Netlify CMS -->
+    <script src="https://unpkg.com/netlify-cms@^2.0.0/dist/netlify-cms.js"></script>
+    <script src="https://identity.netlify.com/v1/netlify-identity-widget.js"></script>
+  </body>
 </html>

--- a/public/index.html
+++ b/public/index.html
@@ -16,14 +16,14 @@
   </body>
   <!-- Handles Netlify identity such as account verification -->
   <script>
-      if (window.netlifyIdentity) {
-          window.netlifyIdentity.on("init", user => {
-              if (!user) {
-                  window.netlifyIdentity.on("login", () => {
-                      document.location.href = "/admin/";
-                  });
-              }
+    if (window.netlifyIdentity) {
+      window.netlifyIdentity.on("init", user => {
+        if (!user) {
+          window.netlifyIdentity.on("login", () => {
+            document.location.href = "/admin/";
           });
-      }
+        }
+      });
+    }
   </script>
 </html>

--- a/src/components/TheNavigation.vue
+++ b/src/components/TheNavigation.vue
@@ -1,37 +1,45 @@
 <template>
-    <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
-      <a
-        class="navbar-brand"
-        href="#">Vue boilerplate docs</a>
+  <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
+    <a
+      class="navbar-brand"
+      href="#">Vue boilerplate docs</a>
 
-      <button
-        class="navbar-toggler"
-        type="button"
-        data-toggle="collapse"
-        data-target="#navbarSupportedContent"
-        aria-controls="navbarSupportedContent"
-        aria-expanded="false"
-        aria-label="Toggle navigation">
-        <span class="navbar-toggler-icon"></span>
-      </button>
+    <button
+      class="navbar-toggler"
+      type="button"
+      data-toggle="collapse"
+      data-target="#navbarSupportedContent"
+      aria-controls="navbarSupportedContent"
+      aria-expanded="false"
+      aria-label="Toggle navigation">
+      <span class="navbar-toggler-icon"></span>
+    </button>
 
-      <div
-        class="collapse navbar-collapse"
-        id="navbarSupportedContent">
-        <ul class="navbar-nav mr-auto">
-          <li class="nav-item">
-            <router-link to="/" class="nav-link" >Getting started</router-link>
-          </li>
-          <li class="nav-item">
-            <router-link to="/bootstrap" class="nav-link" >Bootstrap</router-link>
-          </li>
-          <li class="nav-item">
-            <router-link to="/icons" class="nav-link" >Icons</router-link>
-          </li>
-          <li class="nav-item">
-            <router-link to="/testing" class="nav-link" >Testing</router-link>
-          </li>
-        </ul>
-      </div>
-    </nav>
+    <div
+      class="collapse navbar-collapse"
+      id="navbarSupportedContent">
+      <ul class="navbar-nav mr-auto">
+        <li class="nav-item">
+          <router-link to="/" class="nav-link" >
+            Getting started
+          </router-link>
+        </li>
+        <li class="nav-item">
+          <router-link to="/bootstrap" class="nav-link" >
+            Bootstrap
+          </router-link>
+        </li>
+        <li class="nav-item">
+          <router-link to="/icons" class="nav-link" >
+            Icons
+          </router-link>
+        </li>
+        <li class="nav-item">
+          <router-link to="/testing" class="nav-link" >
+            Testing
+          </router-link>
+        </li>
+      </ul>
+    </div>
+  </nav>
 </template>

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -1,17 +1,17 @@
 <template>
   <div>
-      <h1>Frontend vue boilerplate</h1>
-      <p>This is the vue js frontend boilerplate that
-      we use for new projects.</p>
-      <p>From this boilerplate you get the following</p>
-      <ul>
-        <li>Simple file structure</li>
-        <li>Bootstrap</li>
-        <li>Material icons</li>
-        <li>Prendering</li>
-        <li>Example unit tests</li>
-        <li>Linting rules</li>
-      </ul>
+    <h1>Frontend vue boilerplate</h1>
+    <p>This is the vue js frontend boilerplate that
+    we use for new projects.</p>
+    <p>From this boilerplate you get the following</p>
+    <ul>
+      <li>Simple file structure</li>
+      <li>Bootstrap</li>
+      <li>Material icons</li>
+      <li>Prendering</li>
+      <li>Example unit tests</li>
+      <li>Linting rules</li>
+    </ul>
   </div>
 </template>
 

--- a/src/views/Icons.vue
+++ b/src/views/Icons.vue
@@ -1,17 +1,35 @@
 <template>
   <div>
     <h1>Icons</h1>
-    <p>We have added an example component that makes it easy
-    to use icons across the entire project.</p>
+    <p>
+      We have added an example component that makes it easy
+      to use icons across the entire project.
+    </p>
+    <p>
+      The icon pack we included is material icons.
+      If you include
+      <code>SgIcon</code>
+      component in another component,
+      then you wil be able to use it like this
+    </p>
+    <pre class="pre-scrollable">
+      <code>&lt;sg-icon type="person"&gt;&lt;/sg-icon&gt;</code>
+    </pre>
 
-    <p>The icon pack we included is material icons.
-    If you include <code>SgIcon</code> component in another component,
-    then you wil be able to use it like this</p>
-    <pre class="pre-scrollable"> <code>&lt;sg-icon type="person"&gt;&lt;/sg-icon&gt;</code></pre>
-
-    <p>This will give you the material user icon person <sg-icon type="person"></sg-icon></p>
-    <p>The <code>Sg</code> prefix in the component name is short for Salling group.</p>
-    <p>We use this prefix when adhering to the vue style-guide rule about <a href="https://vuejs.org/v2/style-guide/#Base-component-names-strongly-recommended" target="_blank">Base component names</a></p>
+    <p>This will give you the material user icon person
+      <sg-icon type="person"></sg-icon>
+    </p>
+    <p>
+      The
+      <code>Sg</code>
+      prefix in the component name is short for Salling group.
+    </p>
+    <p>
+      We use this prefix when adhering to the vue style-guide rule about
+      <a :href="vueDocs" target="_blank">
+        Base component names
+      </a>
+    </p>
   </div>
 </template>
 
@@ -22,6 +40,11 @@ export default {
   name: 'icons',
   components: {
     SgIcon,
+  },
+  data() {
+    return {
+      vueDocs: 'https://vuejs.org/v2/style-guide/#Base-component-names-strongly-recommended',
+    };
   },
 };
 </script>

--- a/src/views/Testing.vue
+++ b/src/views/Testing.vue
@@ -1,11 +1,24 @@
 <template>
   <div>
     <h1>Testing</h1>
-    <p>To give you a few examples of the absolute simplest of unit tests we have included a test for the SgIcon component.</p>
+    <p>
+      To give you a few examples of the absolute simplest of
+      unit tests we have included a test for the SgIcon component.
+    </p>
 
-    <p>The test can be found in <code>test/unit/SgIcon.spec.js</code></p>
+    <p>
+      The test can be found in
+      <code>test/unit/SgIcon.spec.js</code>
+    </p>
 
-    <p>We use vue-test-utils as our standard for writing unit tests for our application. More examples and full documentaiton can be found here <a href="https://vue-test-utils.vuejs.org/" target="_blank">Vue Test Utils</a></p>
+    <p>
+      We use vue-test-utils as our standard for writing
+      unit tests for our application. More examples and
+      full documentaiton can be found here
+      <a href="https://vue-test-utils.vuejs.org/" target="_blank">
+        Vue Test Utils
+      </a>
+    </p>
 
   </div>
 </template>

--- a/tests/e2e/.eslintrc.js
+++ b/tests/e2e/.eslintrc.js
@@ -7,6 +7,7 @@ module.exports = {
     'cypress/globals': true
   },
   rules: {
-    strict: 'off'
+    strict: 'off',
+    'max-len': 'off'
   }
 }

--- a/vue.config.js
+++ b/vue.config.js
@@ -1,6 +1,6 @@
-const path = require('path')
-const PrerenderSPAPlugin = require('prerender-spa-plugin')
-const copyWebpackPlugin = require('copy-webpack-plugin')
+const path = require('path');
+const PrerenderSPAPlugin = require('prerender-spa-plugin');
+const copyWebpackPlugin = require('copy-webpack-plugin');
 
 module.exports = {
   configureWebpack: {
@@ -13,16 +13,16 @@ module.exports = {
           '/testing',
           '/bootstrap',
         ],
-      })
-    ]
+      }),
+    ],
   },
-  chainWebpack: config => {
+  chainWebpack: (config) => {
     config
-        .plugin('copy')
-        .use(copyWebpackPlugin, [[{
-          from: 'public',
-          ignore: ['./index.html', 'DS_Store']
-        }]])
+      .plugin('copy')
+      .use(copyWebpackPlugin, [[{
+        from: 'public',
+        ignore: ['./index.html', 'DS_Store'],
+      }]]);
   },
   css: {
     loaderOptions: {


### PR DESCRIPTION
There was no .editorconfig, so IDE's defaulted to 4 space indentation.
There was a lot of linting errors caused by the max-len rule and one by
dependencies.

- add .editorconfig with some default rules
- move copy-webpack-plugin from devDependencies to dependencies
- fix max-len linting error
- fix indentations (four spaces changed to two)